### PR TITLE
appends to CPPFLAGS rather than overwriting it

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -14,7 +14,7 @@ endif
 # Compiler flags
 CFLAGS = -O2 -m64
 #CFLAGS = -Wall -O2 -pg -m64
-CPPFLAGS = -O2 -D_FILE_OFFSET_BITS=64 
+CPPFLAGS += -O2 -D_FILE_OFFSET_BITS=64
 #CPPFLAGS = -O2 -Wall -pg -D_FILE_OFFSET_BITS=64
 # Included libraries (zlib)
 LIB = -lz 


### PR DESCRIPTION
This assures that user defined settings in CPPFLAGS do not get overwritten completely. If headers are not installed in standard locations, the appropriate `-I/path/to/include` flags are often set in `CPPFLAGS`, so these really shouldn't be overwritten.