### PR TITLE
make install target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.d
+*.o
+/bin
+/cpp/vcftools
+/lib

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ install:
 
 .PHONY: clean
 clean:
+	rm -f $(MANDIR)/vcftools.1
 	@for dir in $(DIRS); do \
 	  cd $$dir && $(MAKE) $(MAKEFLAGS) clean && cd .. ; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,16 @@ export MANDIR = ${PREFIX}/bin/man1
 export MODDIR = ${PREFIX}/lib/perl5/site_perl
 
 DIRS = cpp perl
-install:
-	    @mkdir -p $(BINDIR); mkdir -p $(MODDIR); mkdir -p $(MANDIR); \
-	    cp ${SRCDIR}/cpp/vcftools.1 $(MANDIR); \
-        for dir in $(DIRS); do cd $$dir && $(MAKE) $(MAKEFLAGS) && cd ..; done
 
+.PHONY: install
+install:
+	install -Dm644 ${SRCDIR}/cpp/vcftools.1 $(MANDIR)/vcftools.1
+	@for dir in $(DIRS) ; do \
+	  cd $$dir && $(MAKE) $(MAKEFLAGS) install && cd .. ; \
+	done
+
+.PHONY: clean
 clean:
-		@for dir in $(DIRS); do cd $$dir && $(MAKE) clean && cd ..; done
+	@for dir in $(DIRS); do \
+	  cd $$dir && $(MAKE) $(MAKEFLAGS) clean && cd .. ; \
+	done

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -50,7 +50,12 @@ bgzf: bgzf.c
 	$(CPP) -c $(CPPFLAGS) $*.cpp -o $*.o
 	$(CPP) -MM $(CPPFLAGS) $*.cpp > $*.d
 
+.PHONY: install
+install:
+	install -Dm755 $(CURDIR)/vcftools $(BINDIR)/vcftools
+
 # remove compilation products
+.PHONY: clean
 clean:
 	@rm -f vcftools *.o *.d
 	@rm -f $(BINDIR)/vcftools

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -51,11 +51,11 @@ bgzf: bgzf.c
 	$(CPP) -MM $(CPPFLAGS) $*.cpp > $*.d
 
 .PHONY: install
-install:
+install: vcftools
 	install -Dm755 $(CURDIR)/vcftools $(BINDIR)/vcftools
 
 # remove compilation products
 .PHONY: clean
 clean:
-	@rm -f vcftools *.o *.d
-	@rm -f $(BINDIR)/vcftools
+	rm -f vcftools *.o *.d
+	rm -f $(BINDIR)/vcftools

--- a/perl/Makefile
+++ b/perl/Makefile
@@ -4,10 +4,12 @@ BIN = fill-aa fill-an-ac fill-fs fill-ref-md5 vcf-annotate vcf-compare vcf-conca
     vcf-query vcf-shuffle-cols vcf-sort vcf-stats vcf-subset vcf-to-tab vcf-tstv vcf-validator
 MOD = FaSlice.pm Vcf.pm VcfStats.pm
 
+.PHONY: install
 install:
 	for i in $(BIN); do install -Dm755 $(CURDIR)/$$i $(BINDIR)/$$i; done; \
 	for i in $(MOD); do install -Dm644 $(CURDIR)/$$i $(MODDIR)/$$i; done;
 
+.PHONY: clean
 clean:
-		@for i in $(BIN); do rm -f $(BINDIR)/$$i; done; \
-        for i in $(MOD); do rm -f $(MODDIR)/$$i; done; 
+	for i in $(BIN); do rm -f $(BINDIR)/$$i; done; \
+	for i in $(MOD); do rm -f $(MODDIR)/$$i; done;

--- a/perl/Makefile
+++ b/perl/Makefile
@@ -5,8 +5,8 @@ BIN = fill-aa fill-an-ac fill-fs fill-ref-md5 vcf-annotate vcf-compare vcf-conca
 MOD = FaSlice.pm Vcf.pm VcfStats.pm
 
 install:
-	    @for i in $(BIN); do cp $(CURDIR)/$$i $(BINDIR)/$$i; done; \
-        for i in $(MOD); do cp $(CURDIR)/$$i $(MODDIR)/$$i; done; 
+	for i in $(BIN); do install -Dm755 $(CURDIR)/$$i $(BINDIR)/$$i; done; \
+	for i in $(MOD); do install -Dm644 $(CURDIR)/$$i $(MODDIR)/$$i; done;
 
 clean:
 		@for i in $(BIN); do rm -f $(BINDIR)/$$i; done; \

--- a/perl/Makefile
+++ b/perl/Makefile
@@ -6,10 +6,10 @@ MOD = FaSlice.pm Vcf.pm VcfStats.pm
 
 .PHONY: install
 install:
-	for i in $(BIN); do install -Dm755 $(CURDIR)/$$i $(BINDIR)/$$i; done; \
-	for i in $(MOD); do install -Dm644 $(CURDIR)/$$i $(MODDIR)/$$i; done;
+	for i in $(BIN); do install -Dm755 $(CURDIR)/$$i $(BINDIR)/$$i; done
+	for i in $(MOD); do install -Dm644 $(CURDIR)/$$i $(MODDIR)/$$i; done
 
 .PHONY: clean
 clean:
-	for i in $(BIN); do rm -f $(BINDIR)/$$i; done; \
-	for i in $(MOD); do rm -f $(MODDIR)/$$i; done;
+	for i in $(BIN); do rm -f $(BINDIR)/$$i; done
+	for i in $(MOD); do rm -f $(MODDIR)/$$i; done


### PR DESCRIPTION
This PR adresses a few issues I had concerning the `install` target.

My installation procedure looked like this to install to `/usr` (without patching any of the `Makefile`s):

```
make
make \
  PREFIX=/usr \
  MANDIR=/usr/share/man/man1 \
  install
```

What I realized then was that this neither installed `/usr/bin/vcftools` nor that the perl scripts had execute permissions. This PR adresses these issues.

Along the way I also a) declared both `clean` and `install` targets as phony (which they should be, because they do not reference names of files that should be built, but are just a recipe) and b) added a `.gitignore` to ignore the built files from version control.