### PR TITLE
conformity in cpp/Makefile

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -4,51 +4,50 @@
 
 # Compiler
 CC = gcc
-CPP = g++
+CXX = g++
+
 # Output executable
 EXECUTABLE = vcftools
+
 # Flag used to turn on compilation of PCA routines
 ifndef VCFTOOLS_PCA
 	VCFTOOLS_PCA = 0
 endif
-# Compiler flags
-CFLAGS = -O2 -m64
-#CFLAGS = -Wall -O2 -pg -m64
-CPPFLAGS += -O2 -D_FILE_OFFSET_BITS=64
-#CPPFLAGS = -O2 -Wall -pg -D_FILE_OFFSET_BITS=64
-# Included libraries (zlib)
-LIB = -lz 
-#LIB = -lz -I/opt/local/include/ -L/opt/local/lib/
 
-OBJS = vcftools.o bcf_file.o vcf_file.o variant_file.o \
-	header.o bcf_entry.o vcf_entry.o entry.o entry_getters.o entry_setters.o \
-	vcf_entry_setters.o bcf_entry_setters.o entry_filters.o variant_file_filters.o variant_file_output.o parameters.o \
-	variant_file_format_convert.o variant_file_diff.o output_log.o bgzf.o gamma.o
+# Compiler flags
+CFLAGS += -O2 -D_FILE_OFFSET_BITS=64
+CXXFLAGS += $(CFLAGS)
+
+# Included libraries (zlib)
+LIBS = -lz
+
+OBJS = vcftools.o bcf_file.o vcf_file.o variant_file.o header.o bcf_entry.o     \
+	vcf_entry.o entry.o entry_getters.o entry_setters.o vcf_entry_setters.o \
+	bcf_entry_setters.o entry_filters.o variant_file_filters.o              \
+	variant_file_output.o parameters.o variant_file_format_convert.o        \
+	variant_file_diff.o output_log.o bgzf.o gamma.o
 
 ifeq ($(VCFTOOLS_PCA), 1)
 	# Define flag for PCA routine compilation
-	CPPFLAGS += -DVCFTOOLS_PCA
+	CXXFLAGS += -DVCFTOOLS_PCA
 	# Add LAPACK library
-	LIB += -llapack	
+	LIBS += -llapack
 	# Add PCA source code
-	OBJS+= dgeev.o
+	OBJS += dgeev.o
 endif
 
 vcftools: $(OBJS)
-	$(CPP) $(CPPFLAGS) $(OBJS) -o vcftools $(LIB) $(LDFLAGS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(OBJS) -o vcftools $(LDFLAGS) $(LIBS)
 ifdef BINDIR
 	cp $(CURDIR)/$@ $(BINDIR)/$@
 endif
-
-bgzf: bgzf.c
-	$(CC) -c $(CFLAGS) $(FLAGS) bgzf.c $(LIB) $(LDFLAGS) -o bgzf.o
 
 # pull in dependency info for *existing* .o files
 -include $(OBJS:.o=.d)
 
 %.o: %.cpp
-	$(CPP) -c $(CPPFLAGS) $*.cpp -o $*.o
-	$(CPP) -MM $(CPPFLAGS) $*.cpp > $*.d
+	$(CXX) -c $(CPPFLAGS) $(CXXFLAGS) $*.cpp -o $*.o
+	$(CXX) -MM $(CPPFLAGS) $(CXXFLAGS) $*.cpp > $*.d
 
 # remove compilation products
 clean:

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -6,9 +6,6 @@
 CC = gcc
 CXX = g++
 
-# Output executable
-EXECUTABLE = vcftools
-
 # Flag used to turn on compilation of PCA routines
 ifndef VCFTOOLS_PCA
 	VCFTOOLS_PCA = 0

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -13,7 +13,7 @@ endif
 
 # Compiler flags
 CFLAGS += -O2 -D_FILE_OFFSET_BITS=64
-CXXFLAGS += $(CFLAGS)
+CXXFLAGS += -O2 -D_FILE_OFFSET_BITS=64
 
 # Included libraries (zlib)
 LIBS = -lz


### PR DESCRIPTION
In general: CPP had been mistaken for CXX:

- CC is the C compiler
- CFLAGS for C compiler flags, used whenever $(CC) is used
- CXX is the C++ compiler
- CXXFLAGS for C++ compiler flags, used whenever $(CXX) is used
- CPPFLAGS are for headers, e.g. -I/path/to/include, used whenever $(CC) -c or $(CXX) -c are used
- LDFLAGS are for library locations, e.g. -L/path/to/lib, used whenever linking occurs
- LIBS are for libs during linking, e.g. -lz (LIBS is more conform than LIB)

This commit adresses these issues. Other changes:

- both CFLAGS and CXXFLAGS append, so the user can specify his/her own flags (like -Wall)
- neither CPPFLAGS nor LDFLAGS are set in any way in the Makefile
  - the defaults of /usr/include and /usr/lib are always included anyway
  - the user only needs to set CPPFLAGS and LDFLAGS if there are libraries in non-standard locations
- -m64 should not be hard-coded because this would *always* compile in 64-bit mode, even if on a 32-bit system
  - -D_FILE_OFFSET_BITS=64 remains in both CFLAGS and CXXFLAGS to enable large-file operations, IIRC -m64 is not necessary for this to work
- the bgzf target was actually never used, so I removed it for now, I hope this is OK