### PR TITLE
Install man pages in ${PREFIX}/share/man/man1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifndef PREFIX
     export PREFIX = ${SRCDIR}
 endif
 export BINDIR = ${PREFIX}/bin
-export MANDIR = ${PREFIX}/bin/man1
+export MANDIR = ${PREFIX}/share/man/man1
 export MODDIR = ${PREFIX}/lib/perl5/site_perl
 
 DIRS = cpp perl


### PR DESCRIPTION
Manual pages should be installed in `${PREFIX}/share/man/man1` so that `man` can find them in its usual search path.