### PR TITLE
Added detection of $TMPDIR to default params

### DIFF
--- a/src/cpp/parameters.cpp
+++ b/src/cpp/parameters.cpp
@@ -145,7 +145,8 @@ parameters::parameters(int argc, char *argv[])
 	stream_in = false;
 	stream_out = false;
 	suppress_allele_output = false;
-	temp_dir = "/tmp/";
+	temp_dir = string(getenv("TMPDIR"));
+	if(temp_dir.empty()) temp_dir = "/tmp/";
 	vcf_filename="";
 	vcf_format = false;
 	vcf_compressed = false;


### PR DESCRIPTION
Added detection of env variable $TMPDIR to initialize contents of temp_dir when it diverges from /tmp. If the content of the variable is empty, it defaults to /tmp/ and is still overridden by flag --temp.

Signed-off-by: Miguel Bernabeu <miguel.bernabeu@bsc.es>