### PR TITLE
Possible to read BED files with or without header using --bed flag

### DIFF
--- a/src/cpp/vcftools.1
+++ b/src/cpp/vcftools.1
@@ -139,7 +139,7 @@ Include or exclude a set of sites on the basis of the reference allele overlappi
 .B --exclude-bed 
 .I <filename>
 .RS 2
-Include or exclude a set of sites on the basis of a BED file. Only the first three columns (chrom, chromStart and chromEnd) are required. The BED file is expected to have a header line. A site will be kept or excluded if any part of any allele (REF or ALT) at a site is within the range of one of the BED entries. 
+Include or exclude a set of sites on the basis of a BED file. Only the first three columns (chrom, chromStart and chromEnd) are required. The BED file may have a header line. A site will be kept or excluded if any part of any allele (REF or ALT) at a site is within the range of one of the BED entries. 
 .RE
 .PP
 .B --thin 


### PR DESCRIPTION
I recently needed to extract exons of gene from a vcf file using exon regions specified in a bed file and I did so using the --bed option. To my surprise, the first exon was missing allthough vcftools output stated that it read the correct number of entries. vcftools treats the first line as a header line regardless of contents which was documented, but nevertheless this was surprising to me. I felt pretty stupid... However, I don't think I am the first to be surprised by this behavior: Googling around for vcftools and "--bed", led to other examples where behavior was assumed, e.g., in http://blogs.helsinki.fi/bioinformatics-viikki/files/2014/09/NGG2014WorkshopIIPracticals3.pdf (page 6, curl'ed bed files have no header) and 
http://wiki.bits.vib.be/index.php/NGS_Exercise.7_annovar. 

I made a small change so that vcftools now works correctly when no header line is given in VCF file, but still works if header line(s) appears in the bed file. It simply checks if the potential header lines are valid bed entry lines and if not they are treated as headers. The number of lines treated as headers lines and bed entries are now also correctly reported. Note that, it will also work with examples with more than one header line such as those from https://genome.ucsc.edu/FAQ/FAQformat.html#format1 