### PR TITLE
Fix configure.ac and Makefile.am's to properly honour DESTDIR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,9 +18,9 @@ AC_PROG_CPP
 
 # Checks for perl.
 AC_PATH_PROGS([PERL], [perl] [perl5], [false])
-if test "x$PERL" = xfalse ; then
+AS_IF([test "x$PERL" = "xfalse"],[
   AC_MSG_ERROR([Perl not found; check your \$PATH.])
-fi
+])
 
 pmdir_relative_path=`\
 $PERL -MConfig \
@@ -34,12 +34,12 @@ AC_ARG_WITH(
       [--with-pmdir=DIR],
       [install Perl modules in DIR]),
     [PMDIR=${withval}],
-    [PMDIR='${prefix}'/"$pmdir_relative_path"])
+    [PMDIR="$pmdir_relative_path"])
 
 AC_SUBST([PMDIR])
 
 # Checks for libraries.
-PKG_CHECK_MODULES(ZLIB, zlib)
+PKG_CHECK_MODULES([ZLIB], [zlib])
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h stdint.h stdlib.h string.h sys/socket.h unistd.h])
@@ -73,9 +73,9 @@ AC_ARG_ENABLE([pca],
               [pca=${enableval}],
               [pca=no])
 
-if test "x${pca}" = "xyes" ; then
-  AC_CHECK_LIB(lapack, dgeev_)
-fi
+AS_IF([test "x$pca" = "xyes"],[
+  AC_SEARCH_LIBS([dgeev_], [lapack])
+])
 
 # Generate output.
 AC_CONFIG_FILES([Makefile

--- a/src/cpp/Makefile.am
+++ b/src/cpp/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = vcftools
 
-vcftools_CPPFLAGS = $(ZLIB_CPPFLAGS)
+vcftools_CPPFLAGS = $(ZLIB_CFLAGS)
 vcftools_LDADD = $(ZLIB_LIBS)
 
 vcftools_SOURCES = \

--- a/src/perl/Makefile.am
+++ b/src/perl/Makefile.am
@@ -24,7 +24,7 @@ dist_bin_SCRIPTS = \
 	vcf-tstv \
 	vcf-validator
 
-pmdir = $(PMDIR)
+pmdir = $(exec_prefix)/$(PMDIR)
 
 dist_pm_DATA = \
 	FaSlice.pm \


### PR DESCRIPTION
* Replaced raw 'if test' conditionals with `AS_IF`, as the latter is more portable
  https://autotools.io/autoconf/arguments.html
* Add quoting for `PKG_CHECK_MODULES` of zlib, as this is considered good practice
  https://autotools.io/pkgconfig/pkg_check_modules.html
* Fix `ZLIB_CPPFLAGS` -> `ZLIB_CFLAGS` incorrect usage
  https://autotools.io/pkgconfig/pkg_check_modules.html
* Do not code `PMDIR` with prefix in the configure script, rather let Automake handle
  this. This is important, as all custom paths in Makefile.am's need to have these
  variables prefixed, as otherwise `make install` cannot temporarily change them.
  https://www.gnu.org/software/automake/manual/html_node/Hard_002dCoded-Install-Paths.html
* Prefer `AC_SEARCH_LIBS` over `AC_CHECK_LIB`, as the former checks whether the function
  can be consumed without actually linking the library. This is important for Gentoo, as
  we handle lapack and the likes differently. If the standard `CPPFLAGS` + `LIBS` does not work
  then `AC_SEARCH_LIBS` proceeds to try the libraries (i.e., `-llapack` here).
  https://autotools.io/autoconf/finding.html

@auton1 @wookietreiber Please have a look and let me know if you need any further edits.