### PR TITLE
Quote shell commands in FaSlice::read_chunk

### DIFF
--- a/src/perl/FaSlice.pm
+++ b/src/perl/FaSlice.pm
@@ -21,6 +21,7 @@ package FaSlice;
 use strict;
 use warnings;
 use Carp;
+use String::ShellQuote qw( shell_quote );
 
 =head2 new
 
@@ -121,10 +122,10 @@ sub read_chunk
         return;
     }
     my $to = $pos + $$self{size};
-    my $cmd = "samtools faidx $$self{file} $chr:$pos-$to";
+    my $cmd = sprintf("samtools faidx %s %s", shell_quote($$self{file}), shell_quote("$chr:$pos-$to"));
     my @out = $self->cmd($cmd) or $self->throw("$cmd: $!");
     my $line = shift(@out);
-    if ( !($line=~/^>$chr:(\d+)-(\d+)/) ) { $self->throw("Could not parse: $line"); }
+    if ( !($line=~/^>\Q$chr\E:(\d+)-(\d+)/) ) { $self->throw("Could not parse: $line"); }
     $$self{from} = $1;
     my $chunk = '';
     while ($line=shift(@out))

--- a/src/perl/FaSlice.pm
+++ b/src/perl/FaSlice.pm
@@ -21,7 +21,6 @@ package FaSlice;
 use strict;
 use warnings;
 use Carp;
-use String::ShellQuote qw( shell_quote );
 
 =head2 new
 
@@ -122,7 +121,7 @@ sub read_chunk
         return;
     }
     my $to = $pos + $$self{size};
-    my $cmd = sprintf("samtools faidx %s %s", shell_quote($$self{file}), shell_quote("$chr:$pos-$to"));
+    my $cmd = "samtools faidx \Q$$self{file}\E \Q$chr:$pos-$to\E";
     my @out = $self->cmd($cmd) or $self->throw("$cmd: $!");
     my $line = shift(@out);
     if ( !($line=~/^>\Q$chr\E:(\d+)-(\d+)/) ) { $self->throw("Could not parse: $line"); }


### PR DESCRIPTION
Fixes vcftools/vcftools#46

Uses String::ShellQuote to protect a samtools command
built from user input, and \Q..\E to protect the regexp
used to parse samtools output when $chr contains special
characters.

E.g., if $chr contains pipes as in
'gi|1028055272|gb|LWRT01000001.1|', quoting
prevents the execution of

`samtools faidx ref.fa gi|1028055272|gb|LWRT01000001.1|:300-400`

and instead calls

`samtools faidx 'ref.fa' 'gi|1028055272|gb|LWRT01000001.1|:300-400'`
