### PR TITLE
Fix FORMAT/FILTER typo in add_FILTER_descriptor()

### DIFF
--- a/src/cpp/header.cpp
+++ b/src/cpp/header.cpp
@@ -356,7 +356,7 @@ int header::add_FILTER_descriptor(const string &in, int index)
 		tokenize(tokens[ui], '=', entry);
 		if (entry.size() < 2)
 		{
-			LOG.warning("Warning: Expected at least 2 parts in FORMAT entry: " + in);
+			LOG.warning("Warning: Expected at least 2 parts in FILTER entry: " + in);
 			continue;
 		}
 		if (entry[0] == "ID") I.ID = entry[1];


### PR DESCRIPTION
The warning log message in add_FILTER_descriptor() states, "Expected at
least 2 parts in FORMAT entry". Correct "FORMAT" to "FILTER".