### PR TITLE
Fix regex used to check *.gz file extension

### DIFF
--- a/src/perl/Vcf.pm
+++ b/src/perl/Vcf.pm
@@ -201,7 +201,7 @@ sub _open
         $tabix_args .= qq['$$self{file}'];
         if ( exists($args{region}) && defined($args{region}) ) { $tabix_args .= qq[ '$args{region}']; }
 
-        if ( -e $$self{file} && $$self{file}=~/\.gz/i )
+        if ( -e $$self{file} && $$self{file}=~/\.gz$/i )
         {
             if ( exists($args{region}) && defined($args{region}) )
             {


### PR DESCRIPTION
Search regex should match whether the file path ends with "gz" extension.

Current regex will return true even any of the parent dirs contain "gz" string.