### PR TITLE
Pull in autoconf header so we can work with large files in 32-bit land

### DIFF
--- a/src/cpp/vcf_file.cpp
+++ b/src/cpp/vcf_file.cpp
@@ -5,6 +5,7 @@
  *      Author: amarcketta
  */
 
+#include "config.h"
 #include "vcf_file.h"
 
 vcf_file::vcf_file(const parameters &p, bool diff)


### PR DESCRIPTION
If we don't reference the autoconf header we're restricted to 32-bit offsets for the vcf file as we won't have _FILE_OFFSET_BITS 64 defined for the call to stat() in vcf_file::open().