### PR TITLE
Use AC_CHECK_FUNCS to check for malloc, realloc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,9 +63,7 @@ AC_SYS_LARGEFILE
 
 # Checks for library functions.
 AC_FUNC_ERROR_AT_LINE
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
-AC_CHECK_FUNCS([gethostbyaddr gethostbyname memset pow select socket sqrt strchr strdup strerror strstr strtol])
+AC_CHECK_FUNCS([gethostbyaddr gethostbyname malloc memset pow realloc select socket sqrt strchr strdup strerror strstr strtol])
 
 # Optional features.
 AC_ARG_ENABLE([pca],


### PR DESCRIPTION
The previous checks for malloc/realloc fail during cross-compilation. This seems to be a common issue¹²³. There are other workarounds, but this seems to be the best approach since it retains the checks.

¹ https://sourceforge.net/p/mingw-w64/mailman/message/36424004/
² https://stackoverflow.com/q/9229079/4410590
³ https://stackoverflow.com/q/67116092/4410590

Fixes #149